### PR TITLE
Changes for supporting direct intuitive touch input to navigate all OpenTyrian menus.

### DIFF
--- a/project/AndroidManifestTemplate.xml
+++ b/project/AndroidManifestTemplate.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.package.name"
       android:versionCode="100"
-      android:versionName="1.0.0 - intiial version"
+      android:versionName="1.0.0 - initial version"
       android:installLocation="auto"
 >
     <application android:label="@string/app_name"
@@ -12,6 +12,7 @@
         <activity android:name=".MainActivity"
                   android:label="@string/app_name"
                   android:alwaysRetainTaskState="true"
+                  android:launchMode="singleInstance"
                   android:screenOrientation="landscape"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode|screenSize|smallestScreenSize"
                   android:windowSoftInputMode="stateUnspecified|adjustPan"

--- a/project/java/MainActivity.java
+++ b/project/java/MainActivity.java
@@ -285,6 +285,17 @@ public class MainActivity extends Activity {
 		}
 		_isPaused = false;
 	}
+
+	@Override
+	public void onWindowFocusChanged (boolean hasFocus) {
+		super.onWindowFocusChanged(hasFocus);
+		if (hasFocus == false) {
+			synchronized(textInput) {
+				// Send 'SDLK_PAUSE' (to enter pause mode) to native code:
+				DemoRenderer.nativeTextInput( 19, 19 );
+			}
+		}
+	}
 	
 	public boolean isPaused()
 	{

--- a/project/java/MainActivity.java
+++ b/project/java/MainActivity.java
@@ -307,6 +307,12 @@ public class MainActivity extends Activity {
 		System.exit(0);
 	}
 
+	public void togglePlainAndroidSoftKeyboardInput()
+	{
+		InputMethodManager imm = (InputMethodManager) getApplicationContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+		imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
+	}
+
 	public void showScreenKeyboard(final String oldText, boolean sendBackspace)
 	{
 		if(Globals.CompatibilityHacksTextInputEmulatesHwKeyboard)

--- a/project/java/Video.java
+++ b/project/java/Video.java
@@ -524,6 +524,21 @@ class DemoRenderer extends GLSurfaceView_SDL.Renderer
 		return 1;
 	}
 
+	public void togglePlainAndroidSoftKeyboardInput() // Called from native code
+	{
+		class Callback implements Runnable
+		{
+			public MainActivity parent;
+			public void run()
+			{
+				parent.togglePlainAndroidSoftKeyboardInput();
+			}
+		}
+		Callback cb = new Callback();
+		cb.parent = context;
+		context.runOnUiThread(cb);
+	}
+
 	public void showScreenKeyboard(final String oldText, int sendBackspace) // Called from native code
 	{
 		class Callback implements Runnable

--- a/project/jni/application/opentyrian/AndroidAppSettings.cfg
+++ b/project/jni/application/opentyrian/AndroidAppSettings.cfg
@@ -15,6 +15,7 @@ SdlVideoResize=y
 SdlVideoResizeKeepAspect=n
 CompatibilityHacks=n
 CompatibilityHacksStaticInit=n
+CompatibilityHacksTextInputEmulatesHwKeyboard=n
 AppUsesMouse=y
 AppNeedsTwoButtonMouse=n
 ShowMouseCursor=n

--- a/project/jni/application/opentyrian/src/jukebox.cpp
+++ b/project/jni/application/opentyrian/src/jukebox.cpp
@@ -101,8 +101,13 @@ void jukebox( void )
 			
 			const int x = VGAScreen->w / 2;
 			
+#ifdef ANDROID
+			draw_font_hv(VGAScreen, x, 170, "Press the Back button to quit the jukebox.",           small_font, centered, 1, 0);
+			draw_font_hv(VGAScreen, x, 180, "Touch to change the song being played.", small_font, centered, 1, 0);
+#else
 			draw_font_hv(VGAScreen, x, 170, "Press ESC to quit the jukebox.",           small_font, centered, 1, 0);
 			draw_font_hv(VGAScreen, x, 180, "Arrow keys change the song being played.", small_font, centered, 1, 0);
+#endif
 			draw_font_hv(VGAScreen, x, 190, buffer,                                     small_font, centered, 1, 4);
 		}
 
@@ -113,10 +118,22 @@ void jukebox( void )
 
 		wait_delay();
 
+#ifdef ANDROID
+		if (mousedown)
+		{
+			wait_noinput(true, true, true);
+			newkey = true;
+			if (mouse_x < 160)
+				lastkey_sym = SDLK_LEFT;
+			else
+				lastkey_sym = SDLK_RIGHT;
+		}
+#else
 		// quit on mouse click
 		Uint16 x, y;
 		if (JE_mousePosition(&x, &y) > 0)
 			trigger_quit = true;
+#endif
 
 		if (newkey)
 		{

--- a/project/jni/application/opentyrian/src/keyboard.cpp
+++ b/project/jni/application/opentyrian/src/keyboard.cpp
@@ -16,6 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+#include "config.h"
 #include "joystick.h"
 #include "keyboard.h"
 #include "network.h"
@@ -128,6 +129,10 @@ void set_mouse_position( int x, int y )
 	}
 }
 
+JE_boolean handle_pause_key = true;
+
+void JE_pauseGame( void );
+
 void service_SDL_events( JE_boolean clear_new )
 {
 	SDL_Event ev;
@@ -144,6 +149,14 @@ void service_SDL_events( JE_boolean clear_new )
 				mouse_y = ev.motion.y * vga_height / scalers[scaler].height;
 				break;
 			case SDL_KEYDOWN:
+				if (handle_pause_key && ev.key.keysym.sym == SDLK_PAUSE)
+				{
+					JE_boolean superPause_save = superPause;
+					superPause = true;
+					JE_pauseGame();
+					superPause = superPause_save;
+					break;
+				}
 				if (ev.key.keysym.mod & KMOD_CTRL)
 				{
 					/* <ctrl><bksp> emergency kill */

--- a/project/jni/application/opentyrian/src/keyboard.h
+++ b/project/jni/application/opentyrian/src/keyboard.h
@@ -50,6 +50,16 @@ void set_mouse_position( int x, int y );
 
 void service_SDL_events( JE_boolean clear_new );
 
+extern JE_boolean handle_pause_key;
+
+static inline
+void service_SDL_events_ignore_pause( JE_boolean clear_new )
+{
+	handle_pause_key = false;
+	service_SDL_events( clear_new );
+	handle_pause_key = true;
+}
+
 void sleep_game( void );
 
 void JE_clearKeyboard( void );

--- a/project/jni/application/opentyrian/src/mainint.cpp
+++ b/project/jni/application/opentyrian/src/mainint.cpp
@@ -1167,21 +1167,20 @@ void JE_doInGameSetup( void )
 
 JE_boolean JE_inGameSetup( void )
 {
+	const JE_byte menu_top = 20, menu_spacing = 20;
+	const JE_shortint menu_items = 6;
+	JE_shortint sel = 1;
 	SDL_Surface *temp_surface = VGAScreen;
 	VGAScreen = VGAScreenSeg; /* side-effect of game_screen */
 
 	JE_boolean returnvalue = false;
 
 	const JE_byte help[6] /* [1..6] */ = {15, 15, 28, 29, 26, 27};
-	JE_byte  sel;
-	JE_boolean quit;
+	JE_boolean quit = false;
 
 	bool first = true;
 
 	//tempScreenSeg = VGAScreenSeg; /* <MXD> ? should work as VGAScreen */
-
-	quit = false;
-	sel = 1;
 
 	JE_barShade(VGAScreen, 3, 13, 217, 137); /*Main Box*/
 	JE_barShade(VGAScreen, 5, 15, 215, 135);
@@ -1194,9 +1193,9 @@ JE_boolean JE_inGameSetup( void )
 	{
 		memcpy(VGAScreen->pixels, VGAScreen2->pixels, VGAScreen->pitch * VGAScreen->h);
 
-		for (x = 0; x < 6; x++)
+		for (x = 0; x < menu_items; x++)
 		{
-			JE_outTextAdjust(VGAScreen, 10, (x + 1) * 20, inGameText[x], 15, ((sel == x+1) << 1) - 4, SMALL_FONT_SHAPES, true);
+			JE_outTextAdjust(VGAScreen, 10, menu_top + x*menu_spacing, inGameText[x], 15, ((sel == x+1) << 1) - 4, SMALL_FONT_SHAPES, true);
 		}
 
 		JE_outTextAdjust(VGAScreen, 120, 3 * 20, detailLevel[processorType-1], 15, ((sel == 3) << 1) - 4, SMALL_FONT_SHAPES, true);
@@ -1217,6 +1216,22 @@ JE_boolean JE_inGameSetup( void )
 
 		tempW = 0;
 		JE_textMenuWait(&tempW, true);
+
+		sel--;
+		if (select_menuitem_by_touch(menu_top, menu_spacing, menu_items, &sel))
+		{
+			sel++;
+			continue;
+		}
+		sel++;
+
+		if (mousedown && sel < 5)
+		{
+			if (lastmouse_x > 160)
+				lastkey_sym = SDLK_RIGHT;
+			else
+				lastkey_sym = SDLK_LEFT;
+		}
 
 		if (inputDetected)
 		{

--- a/project/jni/application/opentyrian/src/mainint.cpp
+++ b/project/jni/application/opentyrian/src/mainint.cpp
@@ -2783,7 +2783,7 @@ void JE_mainKeyboardInput( void )
 	}
 
 	/* pause game */
-	pause_pressed = pause_pressed || keysactive[SDLK_p];
+	pause_pressed = pause_pressed || keysactive[SDLK_p] || keysactive[SDLK_PAUSE];
 
 	/* in-game setup */
 	ingamemenu_pressed = ingamemenu_pressed || keysactive[SDLK_ESCAPE];
@@ -2915,6 +2915,7 @@ void JE_pauseGame( void )
 
 		push_joysticks_as_keyboard();
 		service_SDL_events(true);
+		JE_showVGA();
 
 		if ((newkey && lastkey_sym != SDLK_LCTRL && lastkey_sym != SDLK_RCTRL && lastkey_sym != SDLK_LALT && lastkey_sym != SDLK_RALT)
 		    || JE_mousePosition(&mouseX, &mouseY) > 0)
@@ -2938,6 +2939,8 @@ void JE_pauseGame( void )
 				done = true;
 			}
 		}
+		else
+			SDL_Delay(300);
 
 		wait_delay();
 	} while (!done);
@@ -3172,10 +3175,10 @@ redo:
 					}
 				}
 
-				service_SDL_events(false);
+				service_SDL_events_ignore_pause(false);
 
-				/* mouse input */
-				/*
+				/* mouse input algorithm which is not suitable for touch-emulated mouse */
+#ifndef ANDROID
 				if ((inputDevice == 0 || inputDevice == 2) && has_mouse)
 				{
 					button[0] |= mouse_pressed[0];
@@ -3194,9 +3197,7 @@ redo:
 						set_mouse_position(159, 100);
 					}
 				}
-				*/
-
-
+#endif
 				/* keyboard input */
 				if ((inputDevice == 0 || inputDevice == 1 || inputDevice == 2) && !play_demo)
 				{

--- a/project/jni/application/opentyrian/src/mainint.cpp
+++ b/project/jni/application/opentyrian/src/mainint.cpp
@@ -48,6 +48,8 @@
 #include "vga256d.h"
 #include "video.h"
 
+#include "SDL_screenkeyboard.h"
+
 #include <assert.h>
 #include <ctype.h>
 
@@ -2398,7 +2400,9 @@ void JE_operation( JE_byte slot )
 		wait_noinput(false, true, false);
 
 		JE_barShade(VGAScreen, 65, 55, 255, 155);
-
+#ifdef ANDROID
+		SDL_ANDROID_CallJavaTogglePlainAndroidSoftKeyboardInput();
+#endif
 		bool quit = false;
 		while (!quit)
 		{
@@ -2510,6 +2514,9 @@ void JE_operation( JE_byte slot )
 					case SDLK_RETURN:
 					case SDLK_SPACE:
 						quit = true;
+#ifdef ANDROID
+						SDL_ANDROID_CallJavaTogglePlainAndroidSoftKeyboardInput();
+#endif
 						JE_saveGame(slot, stemp);
 						JE_playSampleNum(S_SELECT);
 						break;

--- a/project/jni/application/opentyrian/src/menus.cpp
+++ b/project/jni/application/opentyrian/src/menus.cpp
@@ -220,15 +220,16 @@ bool select_difficulty( void )
 	JE_loadPic(VGAScreen, 2, false);
 	JE_dString(VGAScreen, JE_fontCenter(difficulty_name[0], FONT_SHAPES), 20, difficulty_name[0], FONT_SHAPES);
 
+	const JE_byte menu_top = 30, menu_spacing = 24;
 	difficultyLevel = 2;
-	int difficulty_max = 3;
+	JE_shortint difficulty_max = 3;
 
 	bool fade_in = true;
 	for (; ; )
 	{
 		for (int i = 1; i <= difficulty_max; i++)
 		{
-			JE_outTextAdjust(VGAScreen, JE_fontCenter(difficulty_name[i], SMALL_FONT_SHAPES), i * 24 + 30, difficulty_name[i], 15, -4 + (i == difficultyLevel ? 2 : 0), SMALL_FONT_SHAPES, true);
+			JE_outTextAdjust(VGAScreen, JE_fontCenter(difficulty_name[i], SMALL_FONT_SHAPES), i * menu_spacing + menu_top, difficulty_name[i], 15, -4 + (i == difficultyLevel ? 2 : 0), SMALL_FONT_SHAPES, true);
 		}
 		JE_showVGA();
 
@@ -240,6 +241,9 @@ bool select_difficulty( void )
 
 		JE_word temp = 0;
 		JE_textMenuWait(&temp, false);
+
+		if (select_menuitem_by_touch(menu_top, menu_spacing, difficulty_max, &difficultyLevel))
+			continue;
 
 		if (SDL_GetModState() & KMOD_SHIFT)
 		{

--- a/project/jni/application/opentyrian/src/menus.cpp
+++ b/project/jni/application/opentyrian/src/menus.cpp
@@ -56,7 +56,8 @@ bool select_gameplay( void )
 	JE_loadPic(VGAScreen, 2, false);
 	JE_dString(VGAScreen, JE_fontCenter(gameplay_name[0], FONT_SHAPES), 20, gameplay_name[0], FONT_SHAPES);
 
-	int gameplay = 1,
+	const JE_byte menu_top = 30, menu_spacing = 24;
+	JE_shortint gameplay = 1,
 	    gameplay_max = 4;
 
 	bool fade_in = true;
@@ -64,7 +65,7 @@ bool select_gameplay( void )
 	{
 		for (int i = 1; i <= gameplay_max; i++)
 		{
-			JE_outTextAdjust(VGAScreen, JE_fontCenter(gameplay_name[i], SMALL_FONT_SHAPES), i * 24 + 30, gameplay_name[i], 15, - 4 + (i == gameplay ? 2 : 0) - (i == 4 ? 4 : 0), SMALL_FONT_SHAPES, true);
+			JE_outTextAdjust(VGAScreen, JE_fontCenter(gameplay_name[i], SMALL_FONT_SHAPES), i * menu_spacing + menu_top, gameplay_name[i], 15, - 4 + (i == gameplay ? 2 : 0) - (i == 4 ? 4 : 0), SMALL_FONT_SHAPES, true);
 		}
 		JE_showVGA();
 
@@ -76,6 +77,9 @@ bool select_gameplay( void )
 
 		JE_word temp = 0;
 		JE_textMenuWait(&temp, false);
+
+		if (select_menuitem_by_touch(menu_top, menu_spacing, gameplay_max, &gameplay))
+			continue;
 
 		if (newkey)
 		{

--- a/project/jni/application/opentyrian/src/menus.cpp
+++ b/project/jni/application/opentyrian/src/menus.cpp
@@ -139,7 +139,8 @@ bool select_episode( void )
 	JE_loadPic(VGAScreen, 2, false);
 	JE_dString(VGAScreen, JE_fontCenter(episode_name[0], FONT_SHAPES), 20, episode_name[0], FONT_SHAPES);
 
-	int episode = 1,
+	const JE_byte menu_top = 20, menu_spacing = 30;
+	JE_shortint episode = 1,
 	    episode_max = EPISODE_MAX - 1;
 
 	bool fade_in = true;
@@ -147,7 +148,7 @@ bool select_episode( void )
 	{
 		for (int i = 1; i <= episode_max; i++)
 		{
-			JE_outTextAdjust(VGAScreen, 20, i * 30 + 20, episode_name[i], 15, -4 + (i == episode ? 2 : 0) - (!episodeAvail[i - 1] ? 4 : 0), SMALL_FONT_SHAPES, true);
+			JE_outTextAdjust(VGAScreen, 20, i * menu_spacing + menu_top, episode_name[i], 15, -4 + (i == episode ? 2 : 0) - (!episodeAvail[i - 1] ? 4 : 0), SMALL_FONT_SHAPES, true);
 		}
 		JE_showVGA();
 
@@ -159,6 +160,9 @@ bool select_episode( void )
 
 		JE_word temp = 0;
 		JE_textMenuWait(&temp, false);
+
+		if (select_menuitem_by_touch(menu_top, menu_spacing, episode_max, &episode))
+			continue;
 
 		if (newkey)
 		{

--- a/project/jni/application/opentyrian/src/menus.cpp
+++ b/project/jni/application/opentyrian/src/menus.cpp
@@ -31,6 +31,26 @@
 
 char episode_name[6][31], difficulty_name[7][21], gameplay_name[5][26];
 
+bool
+select_menuitem_by_touch(JE_byte menu_top, JE_byte menu_spacing, JE_shortint menu_item_count, JE_shortint *current_item)
+{
+	if (!mousedown)
+		return false;
+
+	char new_item = (mouse_y - menu_top) / menu_spacing;
+
+	if (mouse_y >= menu_top && mouse_y < menu_top + (menu_item_count+1) * menu_spacing)
+	{
+		if (new_item == *current_item)
+			return false;
+
+		JE_playSampleNum(S_CURSOR);
+
+		*current_item = new_item;
+	}
+	return true;
+}
+
 bool select_gameplay( void )
 {
 	JE_loadPic(VGAScreen, 2, false);

--- a/project/jni/application/opentyrian/src/menus.h
+++ b/project/jni/application/opentyrian/src/menus.h
@@ -26,6 +26,7 @@ extern char episode_name[6][31], difficulty_name[7][21], gameplay_name[5][26];
 bool select_gameplay( void );
 bool select_episode( void );
 bool select_difficulty( void );
+bool select_menuitem_by_touch(JE_byte menu_top, JE_byte menu_spacing, JE_shortint menu_item_count, JE_shortint *current_item);
 
 #endif /* MENUS_H */
 

--- a/project/jni/application/opentyrian/src/opentyr.cpp
+++ b/project/jni/application/opentyrian/src/opentyr.cpp
@@ -62,7 +62,9 @@ const char *opentyrian_str = "OpenTyrian",
 const char *opentyrian_menu_items[] =
 {
 	"About OpenTyrian",
+#ifndef ANDROID
 	"Toggle Fullscreen",
+#endif
 	"Scaler: None",
 	"Jukebox",
 #ifdef ANDROID
@@ -70,6 +72,15 @@ const char *opentyrian_menu_items[] =
 #endif
 	"Return to Main Menu"
 };
+
+#ifndef ANDROID
+const int menu_item_scaler   = 2;
+const int menu_item_jukebox  = 3;
+#else
+const int menu_item_scaler   = 1;
+const int menu_item_jukebox  = 2;
+const int menu_item_destruct = 3;
+#endif
 
 /* zero-terminated strncpy */
 char *strnztcpy( char *to, const char *from, size_t count )
@@ -107,7 +118,7 @@ void opentyrian_menu( void )
 			const char *text = opentyrian_menu_items[i];
 			char buffer[100];
 
-			if (i == 2) /* Scaler */
+			if (i == menu_item_scaler) /* Scaler */
 			{
 				snprintf(buffer, sizeof(buffer), "Scaler: %s", scalers[temp_scaler].name);
 				text = buffer;
@@ -192,6 +203,7 @@ void opentyrian_menu( void )
 							JE_showVGA();
 							fade_in = true;
 							break;
+#ifndef ANDROID
 						case 1: /* Fullscreen */
 							JE_playSampleNum(S_SELECT);
 
@@ -203,7 +215,8 @@ void opentyrian_menu( void )
 							}
 							set_palette(colors, 0, 255); // for switching between 8 bpp scalers
 							break;
-						case 2: /* Scaler */
+#endif
+						case menu_item_scaler: /* Scaler */
 							JE_playSampleNum(S_SELECT);
 
 							if (scaler != temp_scaler)
@@ -217,7 +230,7 @@ void opentyrian_menu( void )
 								set_palette(colors, 0, 255); // for switching between 8 bpp scalers
 							}
 							break;
-						case 3: /* Jukebox */
+						case menu_item_jukebox: /* Jukebox */
 							JE_playSampleNum(S_SELECT);
 
 							fade_black(10);
@@ -228,7 +241,7 @@ void opentyrian_menu( void )
 							fade_in = true;
 							break;
 #ifdef ANDROID
-						case 4: /* Destruct */
+						case menu_item_destruct: /* Destruct */
 							JE_playSampleNum(S_SELECT);
 							loadDestruct = true;
 							fade_black(10);

--- a/project/jni/application/opentyrian/src/opentyr.cpp
+++ b/project/jni/application/opentyrian/src/opentyr.cpp
@@ -165,7 +165,7 @@ void opentyrian_menu( void )
 					JE_playSampleNum(S_CURSOR);
 					break;
 				case SDLK_LEFT:
-					if (sel == 2)
+					if (sel == menu_item_scaler)
 					{
 						do
 						{
@@ -178,7 +178,10 @@ void opentyrian_menu( void )
 					}
 					break;
 				case SDLK_RIGHT:
-					if (sel == 2)
+#ifdef ANDROID
+				case SDLK_RETURN:
+#endif
+					if (sel == menu_item_scaler)
 					{
 						do
 						{
@@ -189,8 +192,10 @@ void opentyrian_menu( void )
 						while (!can_init_scaler(temp_scaler, fullscreen_enabled));
 						JE_playSampleNum(S_CURSOR);
 					}
+#ifndef ANDROID
 					break;
 				case SDLK_RETURN:
+#endif
 				case SDLK_SPACE:
 					switch (sel)
 					{

--- a/project/jni/application/opentyrian/src/opentyr.cpp
+++ b/project/jni/application/opentyrian/src/opentyr.cpp
@@ -124,6 +124,9 @@ void opentyrian_menu( void )
 				text = buffer;
 			}
 
+			// Destruct is not adapted for touch input, so we show it only if keyboard is used:
+			if (i == menu_item_destruct && (mousedown || lastkey_sym == SDLK_ESCAPE))
+				continue;
 			draw_font_hv_shadow(VGAScreen, VGAScreen->w / 2, (i != maxSel) ? i * menu_spacing + menu_top : 118, text, normal_font, centered, 15, (i != sel) ? -4 : -2, false, 2);
 		}
 

--- a/project/jni/application/opentyrian/src/opentyr.cpp
+++ b/project/jni/application/opentyrian/src/opentyr.cpp
@@ -28,6 +28,7 @@
 #include "jukebox.h"
 #include "keyboard.h"
 #include "loudness.h"
+#include "menus.h"
 #include "mainint.h"
 #include "mtrand.h"
 #include "musmast.h"
@@ -79,7 +80,8 @@ char *strnztcpy( char *to, const char *from, size_t count )
 
 void opentyrian_menu( void )
 {
-	int sel = 0;
+	const JE_byte menu_top = 36, menu_spacing = 20;
+	JE_shortint sel = 0;
 	const int maxSel = COUNTOF(opentyrian_menu_items) - 1;
 	bool quit = false, fade_in = true;
 	
@@ -111,7 +113,7 @@ void opentyrian_menu( void )
 				text = buffer;
 			}
 
-			draw_font_hv_shadow(VGAScreen, VGAScreen->w / 2, (i != maxSel) ? i * 16 + 32 : 118, text, normal_font, centered, 15, (i != sel) ? -4 : -2, false, 2);
+			draw_font_hv_shadow(VGAScreen, VGAScreen->w / 2, (i != maxSel) ? i * menu_spacing + menu_top : 118, text, normal_font, centered, 15, (i != sel) ? -4 : -2, false, 2);
 		}
 
 		JE_showVGA();
@@ -125,6 +127,9 @@ void opentyrian_menu( void )
 
 		tempW = 0;
 		JE_textMenuWait(&tempW, false);
+
+		if (select_menuitem_by_touch(menu_top, menu_spacing, maxSel, &sel))
+			continue;
 
 		if (newkey)
 		{

--- a/project/jni/application/opentyrian/src/setup.cpp
+++ b/project/jni/application/opentyrian/src/setup.cpp
@@ -31,7 +31,9 @@
 
 void JE_textMenuWait( JE_word *waitTime, JE_boolean doGamma )
 {
+#ifdef MENU_SELECT_BY_MOUSE_MOVE
 	set_mouse_position(160, 100);
+#endif
 	
 	do
 	{
@@ -58,6 +60,11 @@ void JE_textMenuWait( JE_word *waitTime, JE_boolean doGamma )
 		
 		if (has_mouse && input_grabbed)
 		{
+#ifdef MENU_SELECT_BY_MOUSE_MOVE
+			/* Whacky hack which changes menu selecton based on
+			 * relative mouse movement does not work with touch
+			 * when a touch tiggers a mousedown which gets mapped
+			 * to SDLK_RETURN above */
 			if (abs(mouse_y - 100) > 10)
 			{
 				inputDetected = true;
@@ -80,6 +87,7 @@ void JE_textMenuWait( JE_word *waitTime, JE_boolean doGamma )
 				}
 				newkey = true;
 			}
+#endif
 		}
 		
 		NETWORK_KEEP_ALIVE();

--- a/project/jni/application/opentyrian/src/tyrian2.cpp
+++ b/project/jni/application/opentyrian/src/tyrian2.cpp
@@ -3352,9 +3352,13 @@ new_game:
 bool JE_titleScreen( JE_boolean animate )
 {
 	bool quit = false;
-
-	const JE_shortint menunum = 7;
-	const JE_byte menu_top = 102, menu_spacing = 14;
+#ifdef ANDROID
+	const JE_shortint menunum = 5; // Quit not possible, Android manages life cycle!
+	const JE_byte menu_top = 96, menu_spacing = 16;
+#else
+	const JE_shortint menunum = 6;
+	const JE_byte menu_top = 96, menu_spacing = 14;
+#endif
 
 	unsigned int arcade_code_i[SA_ENGAGE] = { 0 };
 
@@ -3506,7 +3510,7 @@ bool JE_titleScreen( JE_boolean animate )
 					strcpy(menuText[4], opentyrian_str);  // OpenTyrian override
 
 					/* Draw Menu Text on Screen */
-					for (int i = 0; i < menunum; ++i)
+					for (int i = 0; i <= menunum; ++i)
 					{
 						int x = VGAScreen->w / 2, y = menu_top + i * menu_spacing;
 

--- a/project/jni/application/opentyrian/src/tyrian2.cpp
+++ b/project/jni/application/opentyrian/src/tyrian2.cpp
@@ -3353,12 +3353,13 @@ bool JE_titleScreen( JE_boolean animate )
 {
 	bool quit = false;
 
-	const int menunum = 7;
+	const JE_shortint menunum = 7;
+	const JE_byte menu_top = 102, menu_spacing = 14;
 
 	unsigned int arcade_code_i[SA_ENGAGE] = { 0 };
 
 	JE_word waitForDemo;
-	JE_byte menu = 0;
+	JE_shortint menu = 0;
 	JE_boolean redraw = true,
 	           fadeIn = false;
 
@@ -3507,7 +3508,7 @@ bool JE_titleScreen( JE_boolean animate )
 					/* Draw Menu Text on Screen */
 					for (int i = 0; i < menunum; ++i)
 					{
-						int x = VGAScreen->w / 2, y = 104 + i * 13;
+						int x = VGAScreen->w / 2, y = menu_top + i * menu_spacing;
 
 						draw_font_hv(VGAScreen, x - 1, y - 1, menuText[i], normal_font, centered, 15, -10);
 						draw_font_hv(VGAScreen, x + 1, y + 1, menuText[i], normal_font, centered, 15, -10);
@@ -3527,7 +3528,7 @@ bool JE_titleScreen( JE_boolean animate )
 			memcpy(VGAScreen->pixels, VGAScreen2->pixels, VGAScreen->pitch * VGAScreen->h);
 
 			// highlight selected menu item
-			draw_font_hv(VGAScreen, VGAScreen->w / 2, 104 + menu * 13, menuText[menu], normal_font, centered, 15, -1);
+			draw_font_hv(VGAScreen, VGAScreen->w / 2, menu_top + menu * menu_spacing, menuText[menu], normal_font, centered, 15, -1);
 
 			JE_showVGA();
 
@@ -3543,6 +3544,8 @@ bool JE_titleScreen( JE_boolean animate )
 			if (waitForDemo == 1)
 				play_demo = true;
 
+			if (select_menuitem_by_touch(menu_top, menu_spacing, menunum, &menu))
+				continue;
 			if (newkey)
 			{
 				switch (lastkey_sym)

--- a/project/jni/application/opentyrian/src/tyrian2.cpp
+++ b/project/jni/application/opentyrian/src/tyrian2.cpp
@@ -2377,7 +2377,7 @@ draw_player_shot_loop_end:
 	}
 	else // input handling for pausing, menu, cheats
 	{
-		service_SDL_events(false);
+		service_SDL_events_ignore_pause(false);
 
 		if (newkey)
 		{

--- a/project/jni/sdl-1.2/include/SDL_screenkeyboard.h
+++ b/project/jni/sdl-1.2/include/SDL_screenkeyboard.h
@@ -105,6 +105,9 @@ extern DECLSPEC int SDLCALL SDL_ANDROID_GetScreenKeyboardTextInput(char * textBu
 /* Whether user redefined on-screen keyboard layout via SDL menu, app should not enforce it's own layout in that case */
 extern DECLSPEC int SDLCALL SDL_ANDROID_GetScreenKeyboardRedefinedByUser();
 
+/* Show only the bare Android on-screen keyboard without any text input field */
+extern DECLSPEC void SDLCALL SDL_ANDROID_CallJavaTogglePlainAndroidSoftKeyboardInput();
+
 #ifdef __cplusplus
 }
 #endif

--- a/project/jni/sdl-1.3/src/video/android/SDL_androidvideo.c
+++ b/project/jni/sdl-1.3/src/video/android/SDL_androidvideo.c
@@ -61,6 +61,7 @@ static jclass JavaRendererClass = NULL;
 static jobject JavaRenderer = NULL;
 static jmethodID JavaSwapBuffers = NULL;
 static jmethodID JavaShowScreenKeyboard = NULL;
+static jmethodID JavaTogglePlainAndroidSoftKeyboardInput = NULL;
 static int glContextLost = 0;
 static int showScreenKeyboardDeferred = 0;
 static const char * showScreenKeyboardOldText = "";
@@ -225,6 +226,11 @@ JAVA_EXPORT_NAME(DemoRenderer_nativeGlContextRecreated) ( JNIEnv*  env, jobject 
 #endif
 }
 
+void SDL_ANDROID_CallJavaTogglePlainAndroidSoftKeyboardInput()
+{
+	(*JavaEnv)->CallVoidMethod( JavaEnv, JavaRenderer, JavaTogglePlainAndroidSoftKeyboardInput );
+}
+
 volatile static textInputFinished = 0;
 void SDL_ANDROID_TextInputFinished()
 {
@@ -283,6 +289,7 @@ JAVA_EXPORT_NAME(DemoRenderer_nativeInitJavaCallbacks) ( JNIEnv*  env, jobject t
 	JavaRendererClass = (*JavaEnv)->GetObjectClass(JavaEnv, thiz);
 	JavaSwapBuffers = (*JavaEnv)->GetMethodID(JavaEnv, JavaRendererClass, "swapBuffers", "()I");
 	JavaShowScreenKeyboard = (*JavaEnv)->GetMethodID(JavaEnv, JavaRendererClass, "showScreenKeyboard", "(Ljava/lang/String;I)V");
+	JavaTogglePlainAndroidSoftKeyboardInput = (*JavaEnv)->GetMethodID(JavaEnv, JavaRendererClass, "togglePlainAndroidSoftKeyboardInput", "()V");
 	
 	ANDROID_InitOSKeymap();
 }

--- a/project/jni/sdl-1.3/src/video/android/SDL_androidvideo.h
+++ b/project/jni/sdl-1.3/src/video/android/SDL_androidvideo.h
@@ -68,6 +68,7 @@ extern void SDL_ANDROID_ProcessDeferredEvents();
 extern void SDL_ANDROID_WarpMouse(int x, int y);
 extern void SDL_ANDROID_DrawMouseCursor(int x, int y, int size, int alpha);
 extern void SDL_ANDROID_DrawMouseCursorIfNeeded();
+extern void SDL_ANDROID_CallJavaTogglePlainAndroidSoftKeyboardInput();
 
 
 #if SDL_VERSION_ATLEAST(1,3,0)


### PR DESCRIPTION
Hi Pelya,

In this branch are 16 commits for you to pull. While the 1st commit is just generic to provide the option -r to build.sh for enabling the autostart of the newly installed app (which I badly needed for efficient testing before committing each change), the other changes after this one are specific to support touch input in OpenTyrian menus, to provide a nice way to edit the names of saved games and pause the game when its onPause() callback gets called (it does not block in this situation when the task list if ICS is shown in front of OpenTyrian while it still continues to run normally).

If you don't agree on some patches, just merge the ones you like, and tell me if that is the case.

Please don't merge by manually committing the changes, I guess it would become difficult to handle if you apply some patches by applying the diff yourself and committing it yourself and not just pulling the change.

If there is a problem which needs to be fixed, please ask me if I'd be able to do the fixes on a new branch from which you could them pull the remaining fixed commits.

Of course, the address bernhard.kaindl@gmx.nat used as Author of the patches is not fully correct.
It should rather be @gmx.net, but this may count just as a cheap form of spam protection ;-)

In case you run into some other issues, I guess I'd fix the .gmx.nat then as well.

If you have comments to certain lines,
I guess it's best to start a discussion on a line in the diff view like I have done on "set -eu" as an example.

Cheers,
Bernhard
