### PR TITLE
OpenTTD JGR : upgrade version

### DIFF
--- a/project/jni/application/openttd-jgrpp/AndroidAppSettings.cfg
+++ b/project/jni/application/openttd-jgrpp/AndroidAppSettings.cfg
@@ -7,10 +7,10 @@ AppName="OpenTTD JGR"
 AppFullName=org.openttd.jgrpp
 
 # Application version code (integer)
-AppVersionCode=032001
+AppVersionCode=032101
 
 # Application user-visible version name (string)
-AppVersionName="0.32.0"
+AppVersionName="0.32.1"
 
 # Specify path to download application data in zip archive in the form 'Description|URL|MirrorURL^Description2|URL2|MirrorURL2^...'
 # If you'll start Description with '!' symbol it will be enabled by default, '!!' will also hide the entry from the menu, so it cannot be disabled


### PR DESCRIPTION
I merge from https://github.com/JGRennison/OpenTTD-patches with 0.32.1.
And it is built successfully 
<img src="https://i.imgur.com/Ww021E9.jpg" width="40%" height="30%" title="jgr 0.32.1" alt="RubberDuck"></image>
