### PR TITLE
OpenTTD JGR : bump version

### DIFF
--- a/project/jni/application/openttd-jgrpp/AndroidAppSettings.cfg
+++ b/project/jni/application/openttd-jgrpp/AndroidAppSettings.cfg
@@ -7,10 +7,10 @@ AppName="OpenTTD JGR"
 AppFullName=org.openttd.jgrpp
 
 # Application version code (integer)
-AppVersionCode=032203
+AppVersionCode=032404
 
 # Application user-visible version name (string)
-AppVersionName="0.32.3"
+AppVersionName="0.32.4"
 
 # Specify path to download application data in zip archive in the form 'Description|URL|MirrorURL^Description2|URL2|MirrorURL2^...'
 # If you'll start Description with '!' symbol it will be enabled by default, '!!' will also hide the entry from the menu, so it cannot be disabled
@@ -20,7 +20,7 @@ AppVersionName="0.32.3"
 # You can specify Google Play expansion files in the form 'obb:main.12345' or 'obb:patch.12345' where 12345 is the app version for obb file
 # You can use .zip.xz archives for better compression, but you need to add 'lzma' to CompiledLibraries
 # Generate .zip.xz files like this: zip -0 -r data.zip your-data/* ; xz -8 data.zip
-AppDataDownloadUrl="!!Data files|openttd-data-0.32.3-0.zip.xz^!!Config file|:.openttd/openttd.cfg:openttd-1.4.0.30.cfg^!!MIDI music support (18 Mb)|timidity.zip.xz^!!Internationalization files|icudt62l.zip.xz"
+AppDataDownloadUrl="!!Data files|openttd-data-0.32.4-0.zip.xz^!!Config file|:.openttd/openttd.cfg:openttd-1.4.0.30.cfg^!!MIDI music support (18 Mb)|timidity.zip.xz^!!Internationalization files|icudt62l.zip.xz"
 
 # Reset SDL config when updating application to the new version (y) / (n)
 ResetSdlConfigForThisVersion=y


### PR DESCRIPTION
![Screenshot_20191218-200602_OpenTTD+JGR](https://user-images.githubusercontent.com/10583171/71081119-f32e4a00-21d1-11ea-991d-4840a51873e7.jpg)
OpenTTD JGR 0.32.4 was released few days ago, so I merged source of new version and was built successfully