### PR TITLE
Fix: simutrans video glitch

### DIFF
--- a/project/jni/application/simutrans/AndroidAppSettings.cfg
+++ b/project/jni/application/simutrans/AndroidAppSettings.cfg
@@ -74,7 +74,7 @@ UseGl4es=
 SwVideoMode=y
 
 # Application video output will be resized to fit into native device screen (y)/(n)
-SdlVideoResize=n
+SdlVideoResize=y
 
 # Application resizing will keep 4:3 aspect ratio, with black bars at sides (y)/(n)
 SdlVideoResizeKeepAspect=n


### PR DESCRIPTION
On Simutrans for Android, this fixes the apparent video glitch issue (resolution + flickering) on latest APK found on SourceForge (June 2021, 121.0).

By the way:
- as of 17/08/2021, the Simutrans trunk does not compile with Clang + NDK, due to a code incompatibility introduced on Simutrans on 12/08/2021, commit https://github.com/aburch/simutrans/commit/446284d85e8df07fffc73bfb200a23086d562388. To validate this fix an earlier revision will be required, such as the official 122.0 being r9274.
- I am authoring a nightly build/release pipeline for Android (to be picked up by Simutrans team hopefully), of which your work is essential; thank you very much for your superb work on this repository