### PR TITLE
fix the audio format specification sdl-1.2 is using for 8-bit android audio

### DIFF
--- a/project/jni/sdl-1.2/src/audio/android/SDL_androidaudio.c
+++ b/project/jni/sdl-1.2/src/audio/android/SDL_androidaudio.c
@@ -183,14 +183,14 @@ static int ANDROIDAUD_OpenAudio (_THIS, SDL_AudioSpec *spec)
 
 	this->hidden = NULL;
 
-	if( ! (audioFormat->format == AUDIO_S8 || audioFormat->format == AUDIO_S16) )
+	if( ! (audioFormat->format == AUDIO_U8 || audioFormat->format == AUDIO_S16) )
 	{
 		__android_log_print(ANDROID_LOG_ERROR, "libSDL", "Application requested unsupported audio format - only S8 and S16 are supported");
 		return (-1); // TODO: enable format conversion? Don't know how to do that in SDL
 	}
 
 	bytesPerSample = (audioFormat->format & 0xFF) / 8;
-	audioFormat->format = ( bytesPerSample == 2 ) ? AUDIO_S16 : AUDIO_S8;
+	audioFormat->format = ( bytesPerSample == 2 ) ? AUDIO_S16 : AUDIO_U8;
 
 	__android_log_print(ANDROID_LOG_INFO, "libSDL", "ANDROIDAUD_OpenAudio(): app requested audio bytespersample %d freq %d channels %d samples %d", bytesPerSample, audioFormat->freq, (int)audioFormat->channels, (int)audioFormat->samples);
 
@@ -455,7 +455,7 @@ extern DECLSPEC int SDLCALL SDL_ANDROID_OpenAudioRecording(SDL_AudioSpec *spec)
 
 	recording = *spec;
 
-	if( ! (recording.format == AUDIO_S8 || recording.format == AUDIO_S16) )
+	if( ! (recording.format == AUDIO_U8 || recording.format == AUDIO_S16) )
 	{
 		__android_log_print(ANDROID_LOG_ERROR, "libSDL", "SDL_ANDROID_OpenAudioRecording(): Application requested unsupported audio format - only S8 and S16 are supported");
 		return 0;

--- a/project/jni/sdl-1.2/src/audio/android/SDL_androidaudio.c
+++ b/project/jni/sdl-1.2/src/audio/android/SDL_androidaudio.c
@@ -185,7 +185,7 @@ static int ANDROIDAUD_OpenAudio (_THIS, SDL_AudioSpec *spec)
 
 	if( ! (audioFormat->format == AUDIO_U8 || audioFormat->format == AUDIO_S16) )
 	{
-		__android_log_print(ANDROID_LOG_ERROR, "libSDL", "Application requested unsupported audio format - only S8 and S16 are supported");
+		__android_log_print(ANDROID_LOG_ERROR, "libSDL", "Application requested unsupported audio format - only U8 and S16 are supported");
 		return (-1); // TODO: enable format conversion? Don't know how to do that in SDL
 	}
 
@@ -212,7 +212,7 @@ static int ANDROIDAUD_OpenAudio (_THIS, SDL_AudioSpec *spec)
 		return (-1);
 	}
 
-	__android_log_print(ANDROID_LOG_INFO, "libSDL", "ANDROIDAUD_OpenAudio(): Requesting audio: freq %d channels %d format %s bufsize %d", audioFormat->freq, audioFormat->channels, bytesPerSample == 2 ? "S16" : "S8", audioFormat->size);
+	__android_log_print(ANDROID_LOG_INFO, "libSDL", "ANDROIDAUD_OpenAudio(): Requesting audio: freq %d channels %d format %s bufsize %d", audioFormat->freq, audioFormat->channels, bytesPerSample == 2 ? "S16" : "U8", audioFormat->size);
 	// The returned audioBufferSize may be huge, up to 100 Kb for 44100 because user may have selected large audio buffer to get rid of choppy sound
 	audioBufferSize = (*jniEnv)->CallIntMethod( jniEnv, JavaAudioThread, JavaInitAudio, 
 					(jint)audioFormat->freq, (jint)audioFormat->channels, 
@@ -457,7 +457,7 @@ extern DECLSPEC int SDLCALL SDL_ANDROID_OpenAudioRecording(SDL_AudioSpec *spec)
 
 	if( ! (recording.format == AUDIO_U8 || recording.format == AUDIO_S16) )
 	{
-		__android_log_print(ANDROID_LOG_ERROR, "libSDL", "SDL_ANDROID_OpenAudioRecording(): Application requested unsupported audio format - only S8 and S16 are supported");
+		__android_log_print(ANDROID_LOG_ERROR, "libSDL", "SDL_ANDROID_OpenAudioRecording(): Application requested unsupported audio format - only U8 and S16 are supported");
 		return 0;
 	}
 


### PR DESCRIPTION
The 8-bit audio data format that Android audio actually supports and works if you deliver bytes in that format here is not `AUDIO_S8` (8-bit two's complement signed values) but rather `AUDIO_U8` (8-bit offset binary values, what is normally called "unsigned"), so let's use that format ID.

If you don't want to have to change IDs in whatever else is using your sdl-1.2 all at once, you could instead keep `AUDIO_S8` in the `||` list as well as `AUDIO_U8`, and take it out once the changeover of everything else is complete.

Goes with the other pull request for pelya/BasiliskII-android#7